### PR TITLE
Fix MSVC compilation

### DIFF
--- a/src/reflector/helper.hh
+++ b/src/reflector/helper.hh
@@ -9,6 +9,6 @@ struct dummy_inspector
 };
 
 template <class T>
-auto is_introspectable_test(T const& t) -> decltype(introspect(dummy_inspector{}, const_cast<T&>(t)), std::true_type{});
+auto is_introspectable_test(T& t) -> decltype(introspect(dummy_inspector{}, t), std::true_type{});
 std::false_type is_introspectable_test(...);
 }

--- a/src/reflector/members.hh
+++ b/src/reflector/members.hh
@@ -79,7 +79,7 @@ template <class T>
 constexpr auto get_member_infos(T const& t)
 {
     auto constexpr cnt = member_count<T>;
-    cc::array<member_info, cnt> members;
+    cc::array<member_info, cnt> members = {};
 
     auto builder = detail::MemberInfoBuilder{members.data(), 0, 0};
     rf::do_introspect(builder, const_cast<T&>(t));


### PR DESCRIPTION
The bug is not resolved yet, but this workaround does not appear to have any drawbacks to me
Also fixed an issue where `get_member_infos` would not evaluate to a constant expression because it does not zero-initialize `members`